### PR TITLE
Rubber ammo for some pistols

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -11721,6 +11721,8 @@
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/flashlight/seclite,
 /obj/item/flashlight/seclite,
+/obj/item/ammo_box/c10mm/rubber,
+/obj/item/ammo_box/c10mm/rubber,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "rgv" = (
@@ -13912,6 +13914,8 @@
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/flashlight/seclite,
 /obj/item/flashlight/seclite,
+/obj/item/ammo_box/c10mm/rubber,
+/obj/item/ammo_box/c10mm/rubber,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "uMj" = (
@@ -15260,6 +15264,8 @@
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/flashlight/seclite,
 /obj/item/flashlight/seclite,
+/obj/item/ammo_box/c10mm/rubber,
+/obj/item/ammo_box/c10mm/rubber,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "wAv" = (

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -19632,6 +19632,15 @@
 /obj/item/storage/fancy/ammobox/beanbag,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
+/obj/item/ammo_box/c10mm/rubber,
+/obj/item/ammo_box/c10mm/rubber,
+/obj/item/ammo_box/c10mm/rubber,
+/obj/item/ammo_box/c9mm/rubber,
+/obj/item/ammo_box/c9mm/rubber,
+/obj/item/ammo_box/c9mm/rubber,
+/obj/item/ammo_box/m127mm/rubber,
+/obj/item/ammo_box/m127mm/rubber,
+/obj/item/ammo_box/m127mm/rubber,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "nhf" = (

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -5197,6 +5197,15 @@
 	pixel_y = 11
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_box/c10mm/rubber,
+/obj/item/ammo_box/c10mm/rubber,
+/obj/item/ammo_box/c10mm/rubber,
+/obj/item/ammo_box/c9mm/rubber,
+/obj/item/ammo_box/c9mm/rubber,
+/obj/item/ammo_box/c9mm/rubber,
+/obj/item/ammo_box/m127mm/rubber,
+/obj/item/ammo_box/m127mm/rubber,
+/obj/item/ammo_box/m127mm/rubber,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -5,6 +5,12 @@
 	caliber = "10mm"
 	projectile_type = /obj/item/projectile/bullet/c10mm
 
+/obj/item/ammo_casing/c10mm/rubber
+	name = "10mm rubber bullet casing"
+	desc = "A 10mm rubber bullet casing."
+	caliber = "10mm"
+	projectile_type = /obj/item/projectile/bullet/c10mm/rubber
+
 /obj/item/ammo_casing/c10mm/ap
 	name = "10mm AP bullet casing"
 	desc = "A 10mm AP bullet casing."
@@ -15,12 +21,19 @@
 	desc = "A 10mm JHP bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c10mm/hp
 
-// 9mm 
+
+// 9mm
 /obj/item/ammo_casing/c9mm
 	name = "9mm FMJ bullet casing"
 	desc = "A 9mm FMJ bullet casing."
 	caliber = "9mm"
 	projectile_type = /obj/item/projectile/bullet/c9mm
+
+/obj/item/ammo_casing/c9mm/rubber
+	name = "9mm rubber bullet casing"
+	desc = "A 9mm rubber bullet casing."
+	caliber = "9mm"
+	projectile_type = /obj/item/projectile/bullet/c9mm/rubber
 
 /obj/item/ammo_casing/c9mm/ap
 	name = "9mm AP bullet casing"
@@ -43,6 +56,12 @@
 	desc = "A 12.7mm FMJ bullet casing."
 	caliber = "12.7"
 	projectile_type = /obj/item/projectile/bullet/a127mm
+
+/obj/item/ammo_casing/a127mm/rubber
+	name = "12.7mm rubber bullet casing"
+	desc = "A 12.7mm rubber bullet casing."
+	caliber = "12.7"
+	projectile_type = /obj/item/projectile/bullet/a127mm/rubber
 
 /obj/item/ammo_casing/a127mm/jhp
 	name = "12.7mm JHP bullet casing"

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -59,6 +59,15 @@
 	max_ammo = 30
 	custom_materials = list(/datum/material/iron = 15000, /datum/material/blackpowder = 1500)
 
+/obj/item/ammo_box/c9mm/rubber
+	name = "ammo box (9mm rubber)"
+	icon_state = "9mmbox"
+	caliber = "9mm"
+	ammo_type = /obj/item/ammo_casing/c9mm/rubber
+	max_ammo = 30
+	custom_materials = list(/datum/material/iron = 15000, /datum/material/blackpowder = 1500)
+
+
 /obj/item/ammo_box/c9mm/ap
 	name = "ammo box (9mm AP)"
 	ammo_type = /obj/item/ammo_casing/c9mm/ap
@@ -78,6 +87,14 @@
 	name = "ammo box (10mm)"
 	icon_state = "10mmbox"
 	ammo_type = /obj/item/ammo_casing/c10mm
+	caliber = "10mm"
+	max_ammo = 30
+	custom_materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
+
+/obj/item/ammo_box/c10mm/rubber
+	name = "ammo box (10mm rubber)"
+	icon_state = "10mmbox"
+	ammo_type = /obj/item/ammo_casing/c10mm/rubber
 	caliber = "10mm"
 	max_ammo = 30
 	custom_materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
@@ -706,6 +723,15 @@
 	icon_state = "50aebox"
 	caliber = "12.7"
 	ammo_type = /obj/item/ammo_casing/a127mm
+	max_ammo = 30
+	w_class = WEIGHT_CLASS_NORMAL
+	custom_materials = list(/datum/material/iron = 11000, /datum/material/blackpowder = 1500)
+
+/obj/item/ammo_box/m127mm/rubber
+	name = "ammo box (12.7mm)"
+	icon_state = "50aebox"
+	caliber = "12.7"
+	ammo_type = /obj/item/ammo_casing/a127mm/rubber
 	max_ammo = 30
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron = 11000, /datum/material/blackpowder = 1500)

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -6,6 +6,13 @@
 	wound_bonus = 18
 	bare_wound_bonus = -18
 
+/obj/item/projectile/bullet/c10mm/rubber
+	name = "10mm rubber bullet"
+	damage = 5
+	stamina = 2
+	sharpness = NONE
+	embedding = null
+
 /obj/item/projectile/bullet/c10mm/ap
 	name = "10mm AP bullet"
 	damage = 24
@@ -27,6 +34,13 @@
 	armour_penetration = 0.05 //0.15
 	wound_bonus = 15
 	bare_wound_bonus = -15
+
+/obj/item/projectile/bullet/c9mm/rubber
+	name = "9mm rubber bullet"
+	damage = 5
+	stamina = 3
+	sharpness = NONE
+	embedding = null
 
 /obj/item/projectile/bullet/c9mm/ap
 	name = "9mm AP bullet"
@@ -59,6 +73,14 @@
 	armour_penetration = 0.4
 	wound_bonus = 28
 	bare_wound_bonus = -28
+
+/obj/item/projectile/bullet/a127mm/rubber
+	name = "12.7mm rubber bullet"
+	damage = 6
+	stamina = 3
+	sharpness = NONE
+	embedding = null
+
 
 /obj/item/projectile/bullet/a127mm/jhp
 	name = "12.7mm JHP bullet"

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -8,4 +8,4 @@
 # NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
 ###############################################################################################
 
-MoondancerPony = Host
+theblackflag= Host


### PR DESCRIPTION
adds rubber ammo type  to some of the pistols there are a few boxes of these in BOS NCR  and  the vault

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds rubber ammo type  to some of the pistols there are a few boxes of these in BOS NCR  and  the vault  
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
less then lethal combat is alllways a good thing
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new rubber bullets to pistols
add: Added rubber ammo boxes to NCR BOS and the VAULT
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
